### PR TITLE
update latest page helper

### DIFF
--- a/pagehelper-spring-boot-autoconfigure/pom.xml
+++ b/pagehelper-spring-boot-autoconfigure/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
     <artifactId>pagehelper-spring-boot-autoconfigure</artifactId>
     <name>pagehelper-spring-boot-autoconfigure</name>

--- a/pagehelper-spring-boot-samples/pom.xml
+++ b/pagehelper-spring-boot-samples/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
     <artifactId>pagehelper-spring-boot-samples</artifactId>
     <packaging>pom</packaging>

--- a/pagehelper-spring-boot-starter/pom.xml
+++ b/pagehelper-spring-boot-starter/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
     </parent>
     <artifactId>pagehelper-spring-boot-starter</artifactId>
     <name>pagehelper-spring-boot-starter</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>com.github.pagehelper</groupId>
     <artifactId>pagehelper-spring-boot</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>pom</packaging>
 
     <name>pagehelper-spring-boot</name>
@@ -64,10 +64,10 @@
 
     <properties>
         <mybatis.version>3.4.4</mybatis.version>
-        <pagehelper.version>5.0.2</pagehelper.version>
+        <pagehelper.version>5.0.3</pagehelper.version>
         <mybatis-spring.version>1.3.1</mybatis-spring.version>
         <mybatis-spring-boot.version>1.3.0</mybatis-spring-boot.version>
-        <spring-boot.version>1.5.3.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.4.RELEASE</spring-boot.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -124,33 +124,11 @@
             <id>release</id>
             <build>
                 <plugins>
-                    <!--Compiler-->
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
-                        </configuration>
-                    </plugin>
-                    <!-- Source -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- Javadoc -->
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.9.1</version>
+                        <inherited>true</inherited>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -165,8 +143,8 @@
                     </plugin>
                     <!-- GPG mvn clean deploy -P release -Dgpg.passphrase=YourPassphase-->
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <inherited>true</inherited>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -191,5 +169,33 @@
             </distributionManagement>
         </profile>
     </profiles>
+
+    <build>
+        <plugins>
+            <!--Compiler-->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <inherited>true</inherited>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <!-- Source -->
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <inherited>true</inherited>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <properties>
         <mybatis.version>3.4.4</mybatis.version>
-        <pagehelper.version>5.0.1</pagehelper.version>
+        <pagehelper.version>5.0.2</pagehelper.version>
         <mybatis-spring.version>1.3.1</mybatis-spring.version>
         <mybatis-spring-boot.version>1.3.0</mybatis-spring-boot.version>
         <spring-boot.version>1.5.3.RELEASE</spring-boot.version>


### PR DESCRIPTION
pagehelper-spring-boot 升级到 1.1.2，更新日志：
1. 升级 pagehelper 到 5.0.3
2. 升级 springboot 到 1.5.4.RELEASE
3. 将 maven-compiler-plugin 和 maven-source-plugin 从 release profile 中提出来作为全局插件，并且增加继承属性，解决 `PageHelperAutoConfiguration` 类中的 `@Override` 报错问题。