### PR TITLE
修改 PageInterceptor 的注册方式

### DIFF
--- a/pagehelper-spring-boot-autoconfigure/pom.xml
+++ b/pagehelper-spring-boot-autoconfigure/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>pagehelper-spring-boot-autoconfigure</artifactId>
     <name>pagehelper-spring-boot-autoconfigure</name>

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
@@ -25,18 +25,13 @@
 package com.github.pagehelper.autoconfigure;
 
 import com.github.pagehelper.PageInterceptor;
-import org.apache.ibatis.session.SqlSessionFactory;
-import org.mybatis.spring.boot.autoconfigure.MybatisAutoConfiguration;
+import org.mybatis.spring.boot.autoconfigure.ConfigurationCustomizer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.PostConstruct;
-import java.util.List;
 import java.util.Properties;
 
 /**
@@ -45,16 +40,8 @@ import java.util.Properties;
  * @author liuzh
  */
 @Configuration
-@ConditionalOnBean(SqlSessionFactory.class)
 @EnableConfigurationProperties(PageHelperProperties.class)
-@AutoConfigureAfter(MybatisAutoConfiguration.class)
 public class PageHelperAutoConfiguration {
-
-    @Autowired
-    private List<SqlSessionFactory> sqlSessionFactoryList;
-
-    @Autowired
-    private PageHelperProperties properties;
 
     /**
      * 接受分页插件额外的属性
@@ -67,18 +54,24 @@ public class PageHelperAutoConfiguration {
         return new Properties();
     }
 
-    @PostConstruct
-    public void addPageInterceptor() {
-        PageInterceptor interceptor = new PageInterceptor();
-        Properties properties = new Properties();
-        //先把一般方式配置的属性放进去
-        properties.putAll(pageHelperProperties());
-        //在把特殊配置放进去，由于close-conn 利用上面方式时，属性名就是 close-conn 而不是 closeConn，所以需要额外的一步
-        properties.putAll(this.properties.getProperties());
-        interceptor.setProperties(properties);
-        for (SqlSessionFactory sqlSessionFactory : sqlSessionFactoryList) {
-            sqlSessionFactory.getConfiguration().addInterceptor(interceptor);
-        }
+    @Bean
+    public ConfigurationCustomizer pageHelperConfigurationCustomizer() {
+        return new ConfigurationCustomizer() {
+            @Autowired
+            private PageHelperProperties properties;
+
+            @Override
+            public void customize(org.apache.ibatis.session.Configuration configuration) {
+                PageInterceptor interceptor = new PageInterceptor();
+                Properties properties = new Properties();
+                //先把一般方式配置的属性放进去
+                properties.putAll(pageHelperProperties());
+                //在把特殊配置放进去，由于close-conn 利用上面方式时，属性名就是 close-conn 而不是 closeConn，所以需要额外的一步
+                properties.putAll(this.properties.getProperties());
+                interceptor.setProperties(properties);
+                configuration.addInterceptor(interceptor);
+            }
+        };
     }
 
 }

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-sample-annotation/pom.xml
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-sample-annotation/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot-samples</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>pagehelper-spring-boot-sample-annotation</artifactId>
     <packaging>jar</packaging>

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-sample-xml/pom.xml
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-sample-xml/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot-samples</artifactId>
-        <version>1.1.1</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>pagehelper-spring-boot-sample-xml</artifactId>
     <packaging>jar</packaging>

--- a/pagehelper-spring-boot-samples/pom.xml
+++ b/pagehelper-spring-boot-samples/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>pagehelper-spring-boot-samples</artifactId>
     <packaging>pom</packaging>

--- a/pagehelper-spring-boot-starter/pom.xml
+++ b/pagehelper-spring-boot-starter/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.github.pagehelper</groupId>
         <artifactId>pagehelper-spring-boot</artifactId>
-        <version>1.2.3</version>
+        <version>1.2.4-SNAPSHOT</version>
     </parent>
     <artifactId>pagehelper-spring-boot-starter</artifactId>
     <name>pagehelper-spring-boot-starter</name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>com.github.pagehelper</groupId>
     <artifactId>pagehelper-spring-boot</artifactId>
-    <version>1.2.3</version>
+    <version>1.2.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>pagehelper-spring-boot</name>
@@ -63,10 +63,10 @@
     </modules>
 
     <properties>
-        <mybatis.version>3.4.4</mybatis.version>
+        <mybatis.version>3.4.5</mybatis.version>
         <pagehelper.version>5.1.2</pagehelper.version>
         <mybatis-spring-boot.version>1.3.1</mybatis-spring-boot.version>
-        <spring-boot.version>1.5.7.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.8.RELEASE</spring-boot.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
主要将 PageInterceptor 的注册方式由从 SqlSessionFactory 改为 mybatis-spring-boot 提供的 ConfigurationCustomizer 方式，便于再添加自定义的拦截器并且指定拦截器的顺序。

* 升级 mybatis 到 3.4.5
* 升级 springboot 到 1.5.8.RELEASE
* 修复 pagehelper-spring-boot-samples 版本号不正确的问题
* 修改 PageInterceptor 的注册方式为 ConfigurationCustomizer