### PR TITLE
Update PageHelperAutoConfiguration.java

### DIFF
--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import javax.annotation.PostConstruct;
 import java.util.List;
@@ -48,6 +49,7 @@ import java.util.Properties;
 @ConditionalOnBean(SqlSessionFactory.class)
 @EnableConfigurationProperties(PageHelperProperties.class)
 @AutoConfigureAfter(MybatisAutoConfiguration.class)
+@Lazy(false)
 public class PageHelperAutoConfiguration {
 
     @Autowired


### PR DESCRIPTION
Disable possible lazy initialization setting. Because after spring boot using `spring:main:lazy-initialization=true` annotation to lazy load all beans, `@PostConstruct` method won't run.
中文版本：
如果spring boot 配置懒加载spring:main:lazy-initialization注解。可能会导致@PostConstruct注解的方法不能被执行。所以需要禁用配置类的懒加载行为