### PR TITLE
修复配置文件中kebab-case风格的配置项失效的问题

### DIFF
--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 
 import java.util.List;
@@ -44,8 +45,9 @@ import java.util.List;
  */
 @Configuration
 @ConditionalOnBean(SqlSessionFactory.class)
-@EnableConfigurationProperties(PageHelperProperties.class)
+@EnableConfigurationProperties(PageHelperPropertiesProcessKebabCase.class)
 @AutoConfigureAfter(MybatisAutoConfiguration.class)
+@Import(PageHelperProperties.class)
 @Lazy(false)
 public class PageHelperAutoConfiguration implements InitializingBean {
 
@@ -53,7 +55,7 @@ public class PageHelperAutoConfiguration implements InitializingBean {
 
     private final PageHelperProperties properties;
 
-    public PageHelperAutoConfiguration(List<SqlSessionFactory> sqlSessionFactoryList, PageHelperProperties properties) {
+    public PageHelperAutoConfiguration(List<SqlSessionFactory> sqlSessionFactoryList, PageHelperProperties properties, PageHelperPropertiesProcessKebabCase propertiesKC) {
         this.sqlSessionFactoryList = sqlSessionFactoryList;
         this.properties = properties;
     }

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperProperties.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperProperties.java
@@ -24,7 +24,7 @@
 
 package com.github.pagehelper.autoconfigure;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
 
 import java.util.Properties;
 
@@ -33,10 +33,8 @@ import java.util.Properties;
  *
  * @author liuzh
  */
-@ConfigurationProperties(prefix = PageHelperProperties.PAGEHELPER_PREFIX)
+@Component
 public class PageHelperProperties extends Properties {
-
-    public static final String PAGEHELPER_PREFIX = "pagehelper";
 
     public Boolean getOffsetAsPageNum() {
         return Boolean.valueOf(getProperty("offsetAsPageNum"));

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperPropertiesProcessKebabCase.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperPropertiesProcessKebabCase.java
@@ -1,0 +1,173 @@
+package com.github.pagehelper.autoconfigure;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Optional;
+
+/**
+ * 原来的{@link PageHelperProperties}继承了{@link java.util.Properties}<br>
+ * 在使用中发现SpringBoot会直接将application.yml(application.properties)的配置名原样set到集合中，
+ * 这样会导致配置文件里的kebab-case风格配置映射到配置类中还是kebab-case而不是camelCase，
+ * 之后设置属性的时候就会因为找不到camelCase的配置导致失效。
+ * <br>
+ * 所有kebab-case风格的配置项都会产生这个问题，即配置不生效。
+ * <br>
+ * 这个类不继承{@link java.util.Properties}，用于提前接收配置文件中的配置项，
+ * 由于没有继承{@link java.util.Properties}，SpringBoot可以做正常的风格转换，
+ * 转换完成后再将camelCase风格的配置放到原来的{@link PageHelperProperties}中
+ *
+ * @author showen
+ */
+@ConfigurationProperties(prefix = PageHelperPropertiesProcessKebabCase.PAGEHELPER_PREFIX)
+public class PageHelperPropertiesProcessKebabCase {
+
+    public static final String PAGEHELPER_PREFIX = "pagehelper";
+
+    private final PageHelperProperties properties;
+    private Boolean offsetAsPageNum;
+    private Boolean rowBoundsWithCount;
+    private Boolean pageSizeZero;
+    private Boolean reasonable;
+    private Boolean supportMethodsArguments;
+    private String dialect;
+    private String helperDialect;
+    private Boolean autoRuntimeDialect;
+    private Boolean autoDialect;
+    private Boolean closeConn;
+    private String params;
+    private Boolean defaultCount;
+    private String dialectAlias;
+    private String autoDialectClass;
+
+    @Autowired
+    public PageHelperPropertiesProcessKebabCase(PageHelperProperties properties) {
+        this.properties = properties;
+    }
+
+    public Boolean getOffsetAsPageNum() {
+        return offsetAsPageNum;
+    }
+
+    public void setOffsetAsPageNum(Boolean offsetAsPageNum) {
+        this.offsetAsPageNum = offsetAsPageNum;
+        Optional.ofNullable(offsetAsPageNum).ifPresent(properties::setOffsetAsPageNum);
+    }
+
+    public Boolean getRowBoundsWithCount() {
+        return rowBoundsWithCount;
+    }
+
+    public void setRowBoundsWithCount(Boolean rowBoundsWithCount) {
+        this.rowBoundsWithCount = rowBoundsWithCount;
+        Optional.ofNullable(rowBoundsWithCount).ifPresent(properties::setRowBoundsWithCount);
+    }
+
+    public Boolean getPageSizeZero() {
+        return pageSizeZero;
+    }
+
+    public void setPageSizeZero(Boolean pageSizeZero) {
+        this.pageSizeZero = pageSizeZero;
+        Optional.ofNullable(pageSizeZero).ifPresent(properties::setPageSizeZero);
+    }
+
+    public Boolean getReasonable() {
+        return reasonable;
+    }
+
+    public void setReasonable(Boolean reasonable) {
+        this.reasonable = reasonable;
+        Optional.ofNullable(reasonable).ifPresent(properties::setReasonable);
+    }
+
+    public Boolean getSupportMethodsArguments() {
+        return supportMethodsArguments;
+    }
+
+    public void setSupportMethodsArguments(Boolean supportMethodsArguments) {
+        this.supportMethodsArguments = supportMethodsArguments;
+        Optional.ofNullable(supportMethodsArguments).ifPresent(properties::setSupportMethodsArguments);
+    }
+
+    public String getDialect() {
+        return dialect;
+    }
+
+    public void setDialect(String dialect) {
+        this.dialect = dialect;
+        Optional.ofNullable(dialect).ifPresent(properties::setDialect);
+    }
+
+    public String getHelperDialect() {
+        return helperDialect;
+    }
+
+    public void setHelperDialect(String helperDialect) {
+        this.helperDialect = helperDialect;
+        Optional.ofNullable(helperDialect).ifPresent(properties::setHelperDialect);
+    }
+
+    public Boolean getAutoRuntimeDialect() {
+        return autoRuntimeDialect;
+    }
+
+    public void setAutoRuntimeDialect(Boolean autoRuntimeDialect) {
+        this.autoRuntimeDialect = autoRuntimeDialect;
+        Optional.ofNullable(autoRuntimeDialect).ifPresent(properties::setAutoRuntimeDialect);
+    }
+
+    public Boolean getAutoDialect() {
+        return autoDialect;
+    }
+
+    public void setAutoDialect(Boolean autoDialect) {
+        this.autoDialect = autoDialect;
+        Optional.ofNullable(autoDialect).ifPresent(properties::setAutoDialect);
+    }
+
+    public Boolean getCloseConn() {
+        return closeConn;
+    }
+
+    public void setCloseConn(Boolean closeConn) {
+        this.closeConn = closeConn;
+        Optional.ofNullable(closeConn).ifPresent(properties::setCloseConn);
+    }
+
+    public String getParams() {
+        return params;
+    }
+
+    public void setParams(String params) {
+        this.params = params;
+        Optional.ofNullable(params).ifPresent(properties::setParams);
+    }
+
+    public Boolean getDefaultCount() {
+        return defaultCount;
+    }
+
+    public void setDefaultCount(Boolean defaultCount) {
+        this.defaultCount = defaultCount;
+        Optional.ofNullable(defaultCount).ifPresent(properties::setDefaultCount);
+    }
+
+    public String getDialectAlias() {
+        return dialectAlias;
+    }
+
+    public void setDialectAlias(String dialectAlias) {
+        this.dialectAlias = dialectAlias;
+        Optional.ofNullable(dialectAlias).ifPresent(properties::setDialectAlias);
+    }
+
+    public String getAutoDialectClass() {
+        return autoDialectClass;
+    }
+
+    public void setAutoDialectClass(String autoDialectClass) {
+        this.autoDialectClass = autoDialectClass;
+        Optional.ofNullable(autoDialectClass).ifPresent(properties::setAutoDialectClass);
+    }
+}


### PR DESCRIPTION
在 #134 中提到，配置文件中的配置项`page-size-zero`失效，检查源码后发现，应该是所有kebab-case风格的配置项都会失效。

问题的原因是在绑定配置项的时候，使用了如下写法：
```java
public class PageHelperProperties extends Properties {
    public void setOffsetAsPageNum(Boolean offsetAsPageNum) {
        setProperty("offsetAsPageNum", offsetAsPageNum.toString());
    }
    //other binding
}
```

正常来说，SpringBoot会在绑定的时候自动做好kebab-case到camelCase的转换，但是在debug的时候发现，由于上面的类继承了`Properties`，SpringBoot貌似是直接调用了`Properties`的`setProperty()`，根本没有走上面类中自己定义的`set()`绑定方法。

对于不是kebab-case风格的配置项，这不会产生问题，两种绑定方式是一样的效果。但是对于一些`kebab-case`风格的配置项就会出现问题，由于直接调用了`Properties`的`setProperty()`，根本就没有做风格转换，这导致实际上会得到一个下面形式的配置项：
```properties
offset-as-page-num=true
```

而我们期待得到的经过转换的形式应该是下面这样：
```properties
offsetAsPageNum=true
```

在根据配置项真正设置*Interceptor*的属性时，使用的是下面的方法：
```java
    public void setProperties(Properties properties) {
        String offsetAsPageNum = properties.getProperty("offsetAsPageNum");
        this.offsetAsPageNum = Boolean.parseBoolean(offsetAsPageNum);
        String rowBoundsWithCount = properties.getProperty("rowBoundsWithCount");
        this.rowBoundsWithCount = Boolean.parseBoolean(rowBoundsWithCount);
        String pageSizeZero = properties.getProperty("pageSizeZero");
        this.pageSizeZero = Boolean.parseBoolean(pageSizeZero);
        String reasonable = properties.getProperty("reasonable");
        this.reasonable = Boolean.parseBoolean(reasonable);
        String supportMethodsArguments = properties.getProperty("supportMethodsArguments");
        this.supportMethodsArguments = Boolean.parseBoolean(supportMethodsArguments);
        String countColumn = properties.getProperty("countColumn");
        if (StringUtil.isNotEmpty(countColumn)) {
            this.countColumn = countColumn;
        }

        PageObjectUtil.setParams(properties.getProperty("params"));
    }
```

很明显，从集合中拿属性的时候都是使用camelCase风格的，但是实际上由于转换失效，集合里都是kebab-case风格的配置，这就会导致取出来的是null，然后`Boolean.parseBoolean(null)`得到的都是false，这就是导致配置失效的原因。

为修复这个问题，新添加了一个`PageHelperPropertiesProcessKebabCase`类，替代之前`PageHelperPropertiesProcess`的角色。新的类用于绑定配置项，并且不继承`Properties`，因此SpringBoot能够做正常的风格转换。转换完成之后，再将camelCase风格的配置放进`PageHelperPropertiesProcess`对象里，之后的流程就和之前一样了，只不过解决了类型转换的问题。

关于为什么当属性类是Properties时，SpringBoot会直接调用`setProperty()`而不做风格转换，目前还没有头绪，没有在官网文档上找到什么说法:(。