### PR TITLE
升级组件以兼容SpringBoot3.x版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Add the following dependency to your pom.xml:
 
 ## v1.4.7 - 2023-06-03
 
+- 升级 JDK 到 17
+- 升级 MyBatis Starter 到 3.0.1
+- 升级 springboot 到 3.0.10
+
+## v1.4.7 - 2023-06-03
+
 - 升级 PageHelper 到 5.3.3
 - 升级 MyBatis 到 3.5.13
 - 升级 MyBatis Starter 到 2.3.1

--- a/pom.xml
+++ b/pom.xml
@@ -63,17 +63,17 @@
     </modules>
 
     <properties>
-        <revision>1.4.7</revision>
+        <revision>1.5.0</revision>
 
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <mybatis.version>3.5.13</mybatis.version>
         <pagehelper.version>5.3.3</pagehelper.version>
-        <mybatis-spring-boot.version>2.3.1</mybatis-spring-boot.version>
-        <spring-boot.version>2.7.12</spring-boot.version>
+        <mybatis-spring-boot.version>3.0.1</mybatis-spring-boot.version>
+        <spring-boot.version>3.0.10</spring-boot.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- 跳跃版本到1.5.0 以支持SpringBoot3
- 升级 JDK 到 17
- 升级 MyBatis Starter 到 3.0.1
- 升级 springboot 到 3.0.10
- 希望在1.5.0版本能快速支持SpringBoot3