### PR TITLE
排除不需要PageHelper 的 SqlSessionFactory

### DIFF
--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperProperties.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperProperties.java
@@ -26,6 +26,7 @@ package com.github.pagehelper.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -36,6 +37,8 @@ import java.util.Properties;
 @ConfigurationProperties(prefix = PageHelperProperties.PAGEHELPER_PREFIX)
 public class PageHelperProperties extends Properties {
     public static final String PAGEHELPER_PREFIX = "pagehelper";
+
+    private List<String> excludeSqlSessionFactoryName;
 
     public Boolean getOffsetAsPageNum() {
         return Boolean.valueOf(getProperty("offsetAsPageNum"));
@@ -147,5 +150,13 @@ public class PageHelperProperties extends Properties {
 
     public void setAutoDialectClass(String autoDialectClass) {
         setProperty("autoDialectClass", autoDialectClass);
+    }
+
+    public List<String> getExcludeSqlSessionFactoryName() {
+        return excludeSqlSessionFactoryName;
+    }
+
+    public void setExcludeSqlSessionFactoryName(List<String> excludeSqlSessionFactoryName) {
+        this.excludeSqlSessionFactoryName = excludeSqlSessionFactoryName;
     }
 }

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperStandardProperties.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperStandardProperties.java
@@ -3,6 +3,7 @@ package com.github.pagehelper.autoconfigure;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -44,6 +45,7 @@ public class PageHelperStandardProperties {
     private Boolean keepOrderBy;
     private Boolean keepSubSelectOrderBy;
     private String sqlParser;
+    private List<String> excludeSqlSessionFactoryName;
 
     @Autowired
     public PageHelperStandardProperties(PageHelperProperties properties) {
@@ -250,5 +252,14 @@ public class PageHelperStandardProperties {
     public void setSqlParser(String sqlParser) {
         this.sqlParser = sqlParser;
         Optional.ofNullable(sqlParser).ifPresent(v -> properties.setProperty("sqlParser", v));
+    }
+
+    public List<String> getExcludeSqlSessionFactoryName() {
+        return excludeSqlSessionFactoryName;
+    }
+
+    public void setExcludeSqlSessionFactoryName(List<String> excludeSqlSessionFactoryName) {
+        this.excludeSqlSessionFactoryName = excludeSqlSessionFactoryName;
+        Optional.ofNullable(excludeSqlSessionFactoryName).ifPresent(properties::setExcludeSqlSessionFactoryName);
     }
 }

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/pom.xml
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pagehelper-spring-boot-samples</artifactId>
+        <groupId>com.github.pagehelper</groupId>
+        <version>1.4.7</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pagehelper-spring-boot-samples-multi-sqlsessionfactory</artifactId>
+    <packaging>jar</packaging>
+    <name>pagehelper-spring-boot-samples-multi-sqlsessionfactory</name>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.mybatis.spring.boot</groupId>
+            <artifactId>mybatis-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.pagehelper</groupId>
+            <artifactId>pagehelper-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/MultiSqlSessionFactoryApplication.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/MultiSqlSessionFactoryApplication.java
@@ -1,0 +1,75 @@
+package tk.mybatis.pagehelper;
+
+import com.github.pagehelper.Page;
+import com.github.pagehelper.PageHelper;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import tk.mybatis.pagehelper.business1.domain.User;
+import tk.mybatis.pagehelper.business1.mapper.UserMapper;
+import tk.mybatis.pagehelper.business2.domain.Blog;
+import tk.mybatis.pagehelper.business2.mapper.BlogMapper;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+@SpringBootApplication
+public class MultiSqlSessionFactoryApplication implements CommandLineRunner {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MultiSqlSessionFactoryApplication.class, args);
+    }
+
+    @Autowired
+    @Qualifier("business1DataSource")
+    private DataSource business1DataSource;
+
+    @Autowired
+    @Qualifier("business2DataSource")
+    private DataSource business2DataSource;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    @Autowired
+    @Qualifier("business1SqlSessionFactory")
+    private SqlSessionFactory business1SqlSessionFactory;
+
+    @Autowired
+    @Qualifier("business2SqlSessionFactory")
+    private SqlSessionFactory business2SqlSessionFactory;
+
+    @Override
+    public void run(String... args) throws Exception {
+        runScript(business1DataSource, "business1.sql");
+        runScript(business2DataSource, "business2.sql");
+        Page<User> userPage = PageHelper.startPage(1, 20);
+        List<User> users = userMapper.selectAll();
+        System.out.println("Total: " + userPage.getTotal());
+        for (User user : users) {
+            System.out.println("Name: " + user.getName());
+        }
+        List<Interceptor> business1 = business1SqlSessionFactory.getConfiguration().getInterceptors();
+        List<Interceptor> business2 = business2SqlSessionFactory.getConfiguration().getInterceptors();
+        System.out.println("business1 interceptor "+ business1);
+        System.out.println("business2 interceptor "+ business2);
+    }
+
+    private void runScript(DataSource dataSource, String sqlPath) throws SQLException, IOException {
+        try (Connection connection = dataSource.getConnection();
+             Reader reader = Resources.getResourceAsReader(sqlPath)) {
+            ScriptRunner scriptRunner = new ScriptRunner(connection);
+            scriptRunner.runScript(reader);
+        }
+    }
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business1/domain/User.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business1/domain/User.java
@@ -1,0 +1,22 @@
+package tk.mybatis.pagehelper.business1.domain;
+
+public class User {
+    private Integer id;
+    private String name;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business1/mapper/UserMapper.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business1/mapper/UserMapper.java
@@ -1,0 +1,11 @@
+package tk.mybatis.pagehelper.business1.mapper;
+import org.apache.ibatis.annotations.Mapper;
+import tk.mybatis.pagehelper.business1.domain.User;
+
+import java.util.List;
+
+@Mapper
+public interface UserMapper {
+
+    List<User> selectAll();
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business2/domain/Blog.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business2/domain/Blog.java
@@ -1,0 +1,33 @@
+package tk.mybatis.pagehelper.business2.domain;
+
+public class Blog {
+    private Integer id;
+
+    private Integer userId;
+
+    private String title;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business2/mapper/BlogMapper.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/business2/mapper/BlogMapper.java
@@ -1,0 +1,12 @@
+package tk.mybatis.pagehelper.business2.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import tk.mybatis.pagehelper.business2.domain.Blog;
+
+import java.util.List;
+
+@Mapper
+public interface BlogMapper {
+
+    List<Blog> selectAllBlog();
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/config/Business1Config.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/config/Business1Config.java
@@ -1,0 +1,46 @@
+package tk.mybatis.pagehelper.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.mybatis.spring.boot.autoconfigure.MybatisProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan(basePackages = "tk.mybatis.pagehelper.business1.mapper", sqlSessionFactoryRef = "business1SqlSessionFactory")
+public class Business1Config {
+
+    @Bean(name = "business1DataSourceProperties")
+    @ConfigurationProperties(prefix = "spring.datasource.business1")
+    public DataSourceProperties business1DataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean(name = "business1DataSource")
+    public DataSource business1DataSource(@Qualifier("business1DataSourceProperties") DataSourceProperties dataSourceProperties) {
+        HikariDataSource hikariDataSource = dataSourceProperties.initializeDataSourceBuilder()
+                .type(HikariDataSource.class).build();
+        hikariDataSource.setPoolName("business1DataSource");
+        return hikariDataSource;
+    }
+
+    @Bean(name = "business1SqlSessionFactory")
+    public SqlSessionFactory business1SqlSessionFactory(@Qualifier("business1DataSource") DataSource dataSource)
+            throws Exception {
+        SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        MybatisProperties mybatisProperties = new MybatisProperties();
+        mybatisProperties.setMapperLocations(new String[]{"tk/mybatis/pagehelper/business1/mapper/*Mapper.xml"});
+        factory.setMapperLocations(mybatisProperties.resolveMapperLocations());
+        return factory.getObject();
+    }
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/config/Business2Config.java
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/java/tk/mybatis/pagehelper/config/Business2Config.java
@@ -1,0 +1,45 @@
+package tk.mybatis.pagehelper.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
+import org.mybatis.spring.boot.autoconfigure.MybatisProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.sql.DataSource;
+
+@Configuration
+@MapperScan(basePackages = "tk.mybatis.pagehelper.business2.mapper", sqlSessionFactoryRef = "business2SqlSessionFactory")
+public class Business2Config {
+
+    @Bean(name = "business2DataSourceProperties")
+    @ConfigurationProperties(prefix = "spring.datasource.business2")
+    public DataSourceProperties business2DataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean(name = "business2DataSource")
+    public DataSource business2DataSource(@Qualifier("business2DataSourceProperties") DataSourceProperties dataSourceProperties) {
+        HikariDataSource hikariDataSource = dataSourceProperties.initializeDataSourceBuilder()
+                .type(HikariDataSource.class).build();
+        hikariDataSource.setPoolName("business2DataSource");
+        return hikariDataSource;
+    }
+
+
+    @Bean(name = "business2SqlSessionFactory")
+    public SqlSessionFactory business1SqlSessionFactory(@Qualifier("business2DataSource") DataSource dataSource)
+            throws Exception {
+        SqlSessionFactoryBean factory = new SqlSessionFactoryBean();
+        factory.setDataSource(dataSource);
+        MybatisProperties mybatisProperties = new MybatisProperties();
+        mybatisProperties.setMapperLocations(new String[]{"tk/mybatis/pagehelper/business2/mapper/*Mapper.xml"});
+        factory.setMapperLocations(mybatisProperties.resolveMapperLocations());
+        return factory.getObject();
+    }
+}

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/application.properties
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/application.properties
@@ -1,0 +1,45 @@
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 abel533@gmail.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+debug=true
+logging.level.root=WARN
+logging.level.tk.mybatis.pagehelper.mapper=TRACE
+#pagehelper.
+pagehelper.autoDialect=true
+pagehelper.closeConn=true
+#\u6D4B\u8BD5\u5C5E\u6027\u6CE8\u5165
+pagehelper.hello=\u4F60\u597D
+pagehelper.nihao=Hello
+pagehelper.offset-as-page-num=true
+pagehelper.count-column=*
+pagehelper.excludeSqlSessionFactoryName = business2SqlSessionFactory
+
+# business1 datasource
+spring.datasource.business1.username = sa
+spring.datasource.business1.url = jdbc:h2:mem:business1
+spring.datasource.business1.driver-class-name = org.h2.Driver
+
+# business2 datasource
+spring.datasource.business2.username = sa
+spring.datasource.business2.url = jdbc:h2:mem:business2
+spring.datasource.business2.driver-class-name = org.h2.Driver

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/business1.sql
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/business1.sql
@@ -1,0 +1,12 @@
+drop table t_user if exists;
+
+create table t_user
+(
+    id int not null primary key auto_increment,
+    name varchar(20)
+);
+
+insert into t_user (name) values ('User1');
+insert into t_user (name) values ('User1 HSQL');
+insert into t_user (name) values ('User1 DERBY');
+insert into t_user (name) values ('User1 DEFAULT');

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/business2.sql
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/business2.sql
@@ -1,0 +1,12 @@
+drop table blog if exists;
+
+CREATE TABLE blog
+(
+    id int not null primary key auto_increment,
+    user_id INT,
+    title     VARCHAR(255)
+);
+
+insert into blog(user_id, title) values (1, 'blog_1');
+insert into blog(user_id, title) values (1, 'blog_2');
+insert into blog(user_id, title) values (1, 'blog_3');

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/tk/mybatis/pagehelper/business1/mapper/UserMapper.xml
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/tk/mybatis/pagehelper/business1/mapper/UserMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2017 abel533@gmail.com
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="tk.mybatis.pagehelper.business1.mapper.UserMapper">
+    <select id="selectAll" resultType="tk.mybatis.pagehelper.business1.domain.User">
+        select * from t_user
+    </select>
+</mapper>

--- a/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/tk/mybatis/pagehelper/business2/mapper/BlogMapper.xml
+++ b/pagehelper-spring-boot-samples/pagehelper-spring-boot-samples-multi-sqlsessionfactory/src/main/resources/tk/mybatis/pagehelper/business2/mapper/BlogMapper.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="tk.mybatis.pagehelper.business2.mapper.BlogMapper">
+    <select id="selectAllBlog" resultType="tk.mybatis.pagehelper.business2.domain.Blog">
+        select *
+        from blog
+    </select>
+</mapper>

--- a/pagehelper-spring-boot-samples/pom.xml
+++ b/pagehelper-spring-boot-samples/pom.xml
@@ -37,6 +37,7 @@
     <modules>
         <module>pagehelper-spring-boot-sample-annotation</module>
         <module>pagehelper-spring-boot-sample-xml</module>
+        <module>pagehelper-spring-boot-samples-multi-sqlsessionfactory</module>
     </modules>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
在多数据源的情况下，有些数据源经使用mybatis-plus 的分页插件
`pagehelper.excludeSqlSessionFactoryName = business2SqlSessionFactory`
支持配置 排除不加载 page-helper 插件