### PR TITLE
添加SqlSessionFactory隔离的声明式配置支持

### DIFF
--- a/pagehelper-spring-boot-autoconfigure/pom.xml
+++ b/pagehelper-spring-boot-autoconfigure/pom.xml
@@ -65,5 +65,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-test</artifactId>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/PageHelperAutoConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * 自定注入分页插件
@@ -44,31 +44,54 @@ import java.util.List;
  */
 @Configuration
 @ConditionalOnBean(SqlSessionFactory.class)
-@EnableConfigurationProperties({PageHelperProperties.class, PageHelperStandardProperties.class})
+@EnableConfigurationProperties({PageHelperProperties.class, PageHelperStandardProperties.class,
+    SqlSessionFactoryIsolatedPageHelperProperties.class})
 @AutoConfigureAfter(MybatisAutoConfiguration.class)
 //@Import(PageHelperProperties.class)
 @Lazy(false)
 public class PageHelperAutoConfiguration implements InitializingBean {
 
-    private final List<SqlSessionFactory> sqlSessionFactoryList;
+    private final Map<String, SqlSessionFactory> sqlSessionFactoryMap;
 
     private final PageHelperProperties properties;
 
-    public PageHelperAutoConfiguration(List<SqlSessionFactory> sqlSessionFactoryList, PageHelperStandardProperties standardProperties) {
-        this.sqlSessionFactoryList = sqlSessionFactoryList;
+    private final SqlSessionFactoryIsolatedPageHelperProperties sqlSessionFactoryIsolatedPageHelperProperties;
+
+    public PageHelperAutoConfiguration(Map<String, SqlSessionFactory> sqlSessionFactoryMap,
+        PageHelperStandardProperties standardProperties,
+        SqlSessionFactoryIsolatedPageHelperProperties sqlSessionFactoryIsolatedPageHelperProperties) {
+        this.sqlSessionFactoryMap = sqlSessionFactoryMap;
         this.properties = standardProperties.getProperties();
+        this.sqlSessionFactoryIsolatedPageHelperProperties = sqlSessionFactoryIsolatedPageHelperProperties;
     }
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        PageInterceptor interceptor = new PageInterceptor();
-        interceptor.setProperties(this.properties);
-        for (SqlSessionFactory sqlSessionFactory : sqlSessionFactoryList) {
+        // prepare default interceptor
+        PageInterceptor defaultInterceptor = new PageInterceptor();
+        defaultInterceptor.setProperties(this.properties);
+        // prepare isolated properties
+        Map<String, SqlSessionFactoryIsolatedPageHelperProperties.PageHelperDedicatedProperties> propertiesMap =
+            sqlSessionFactoryIsolatedPageHelperProperties.getSqlSessionFactoryGroup();
+        sqlSessionFactoryMap.forEach((sqlSessionFactoryBeanName, sqlSessionFactory) -> {
+            // try to find dedicated properties
+            SqlSessionFactoryIsolatedPageHelperProperties.PageHelperDedicatedProperties dedicatedProperties =
+                null == propertiesMap ? null : propertiesMap.get(sqlSessionFactoryBeanName);
+            PageInterceptor interceptor;
+            if (null == dedicatedProperties) {
+                // use default interceptor
+                interceptor = defaultInterceptor;
+            } else {
+                // build dedicated interceptor
+                interceptor = new PageInterceptor();
+                interceptor.setProperties(dedicatedProperties.getProperties());
+            }
+            // register interceptor
             org.apache.ibatis.session.Configuration configuration = sqlSessionFactory.getConfiguration();
             if (!containsInterceptor(configuration, interceptor)) {
                 configuration.addInterceptor(interceptor);
             }
-        }
+        });
     }
 
     /**

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/SqlSessionFactoryIsolatedPageHelperProperties.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/SqlSessionFactoryIsolatedPageHelperProperties.java
@@ -1,0 +1,33 @@
+package com.github.pagehelper.autoconfigure;
+
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * SqlSessionFactory isolated configuration properties for PageHelper.
+ *
+ * @author tigerzhao
+ */
+@ConfigurationProperties(prefix = PageHelperProperties.PAGEHELPER_PREFIX)
+public class SqlSessionFactoryIsolatedPageHelperProperties {
+
+    public static class PageHelperDedicatedProperties extends PageHelperStandardProperties {
+
+        public PageHelperDedicatedProperties() {
+            super(new PageHelperProperties());
+        }
+
+    }
+
+    private Map<String, PageHelperDedicatedProperties> sqlSessionFactoryGroup;
+
+    public Map<String, PageHelperDedicatedProperties> getSqlSessionFactoryGroup() {
+        return sqlSessionFactoryGroup;
+    }
+
+    public void setSqlSessionFactoryGroup(Map<String, PageHelperDedicatedProperties> sqlSessionFactoryGroup) {
+        this.sqlSessionFactoryGroup = sqlSessionFactoryGroup;
+    }
+
+}

--- a/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/SqlSessionFactoryIsolatedPageHelperProperties.java
+++ b/pagehelper-spring-boot-autoconfigure/src/main/java/com/github/pagehelper/autoconfigure/SqlSessionFactoryIsolatedPageHelperProperties.java
@@ -1,3 +1,27 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 abel533@gmail.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package com.github.pagehelper.autoconfigure;
 
 import java.util.Map;

--- a/pagehelper-spring-boot-autoconfigure/src/test/java/com/github/pagehelper/autoconfigure/SqlSessionFactoryIsolatedPageHelperPropertiesTest.java
+++ b/pagehelper-spring-boot-autoconfigure/src/test/java/com/github/pagehelper/autoconfigure/SqlSessionFactoryIsolatedPageHelperPropertiesTest.java
@@ -1,0 +1,100 @@
+package com.github.pagehelper.autoconfigure;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.defaults.DefaultSqlSessionFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+import com.github.pagehelper.PageInterceptor;
+
+/**
+ * Unit test for {@link SqlSessionFactoryIsolatedPageHelperProperties} and {@link PageHelperAutoConfiguration}.
+ *
+ * @author tigerzhao
+ * @date 2026-01-10 21:22
+ */
+@SpringBootTest(classes = {SqlSessionFactoryIsolatedPageHelperPropertiesTest.SqlSessionFactoryConfiguration.class,
+    PageHelperAutoConfiguration.class})
+@TestPropertySource(properties = {"pagehelper.dialect=com.github.pagehelper.dialect.helper.OracleDialect",
+    "pagehelper.sql-session-factory-group.sqlSessionFactory1.dialect=com.github.pagehelper.dialect.helper.MySqlDialect",
+    "pagehelper.sqlSessionFactoryGroup.sqlSessionFactory2.dialect=com.github.pagehelper.dialect.helper.PostgreSqlDialect"})
+class SqlSessionFactoryIsolatedPageHelperPropertiesTest {
+
+    public static class SqlSessionFactoryConfiguration {
+
+        @Bean
+        public SqlSessionFactory sqlSessionFactory1() {
+            return new DefaultSqlSessionFactory(new Configuration());
+        }
+
+        @Bean
+        public SqlSessionFactory sqlSessionFactory2() {
+            return new DefaultSqlSessionFactory(new Configuration());
+        }
+
+        @Bean
+        public SqlSessionFactory sqlSessionFactory3() {
+            return new DefaultSqlSessionFactory(new Configuration());
+        }
+
+    }
+
+    private static final Logger LOGGER =
+        LoggerFactory.getLogger(SqlSessionFactoryIsolatedPageHelperPropertiesTest.class);
+
+    @Autowired
+    private Map<String, SqlSessionFactory> sqlSessionFactoryMap;
+
+    private static Field pageHelperDialectField;
+
+    static {
+        try {
+            pageHelperDialectField = PageInterceptor.class.getDeclaredField("dialect");
+            pageHelperDialectField.setAccessible(true);
+        } catch (NoSuchFieldException | SecurityException e) {
+            LOGGER.warn("Failed to get pageHelper dialect field", e);
+        }
+    }
+
+    @Test
+    public void testForIsolatedPageHelperConfiguration() {
+        sqlSessionFactoryMap.forEach((sqlSessionFactoryBeanName, sqlSessionFactory) -> {
+            if ("sqlSessionFactory1".equals(sqlSessionFactoryBeanName)) {
+                assertInterceptorConfiguration(sqlSessionFactory, "com.github.pagehelper.dialect.helper.MySqlDialect");
+            } else if ("sqlSessionFactory2".equals(sqlSessionFactoryBeanName)) {
+                assertInterceptorConfiguration(sqlSessionFactory,
+                    "com.github.pagehelper.dialect.helper.PostgreSqlDialect");
+            } else {
+                assertInterceptorConfiguration(sqlSessionFactory, "com.github.pagehelper.dialect.helper.OracleDialect");
+            }
+        });
+    }
+
+    private void assertInterceptorConfiguration(SqlSessionFactory sqlSessionFactory, String expectedDialectClassName) {
+        List<Interceptor> interceptors = sqlSessionFactory.getConfiguration().getInterceptors();
+        Assertions.assertFalse(interceptors.isEmpty());
+        Interceptor interceptor = interceptors.get(0);
+        Assertions.assertInstanceOf(PageInterceptor.class, interceptor);
+        if (null != pageHelperDialectField) {
+            try {
+                Assertions.assertEquals(expectedDialectClassName,
+                    pageHelperDialectField.get(interceptor).getClass().getName());
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                LOGGER.warn("Failed to get pageHelper dialect", e);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
添加SqlSessionFactory隔离的声明式配置支持，当不需要复杂的PageInterceptor定制扩展时，可以通过简单的SqlSessionFactory隔离的配置声明实现多PageInterceptor独立配置。